### PR TITLE
Firestoreのセキュリティルールとユーザー更新のテストを追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,5 +1,61 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+
+    function isUserAuthenticated(userId) {
+      return isAnyAuthenticated() && userId == request.auth.uid;
+    }
+
+    function isAnyAuthenticated() {
+      return request.auth != null;
+    }
+
+    function isNotUpdating(fieldName) {
+      return !(fieldName in request.resource.data) || request.resource.data[fieldName] == resource.data[fieldName]
+    }
+
+    function isUserBelongingToGroup(groupId) {
+      return exists(documentPath(['groups', groupId, 'groupUsers', request.auth.uid]))
+    }
+
+    function documentPath(paths) {
+      return path([['databases', database, 'documents'].join('/'), path.join('/')].join('/'));
+    }
+
+    match /users/{userId} {
+      allow get: if isUserAuthenticated(userId);
+      allow create: if isUserAuthenticated(userId);
+      allow update: if isUserAuthenticated(userId) 
+        && isNotUpdating('groupCount')
+        && request.resource.data.updatedAt == request.time
+      ;
+    }
+
+    match /groups/{groupId} {
+      allow get: if isUserBelongingToGroup(groupId);
+      allow update: if isUserBelongingToGroup(groupId);
+
+      match /groupUsers/{userId} {
+        allow get, list: if isUserBelongingToGroup(groupId);
+        allow create: if isUserAuthenticated(userId)
+          && request.resource.data.invitationCode is string
+          && get(documentPath(['invitationCodes', request.resource.data.invitationCode])).data.groupId == groupId
+          // && get(documentPath(['invitationCodes', request.resource.data.invitationCode])).data.expiredAt > request.time
+          && request.resource.data.createdAt == request.time
+        ;
+      }
+    }
+
+    match /invitationCodes/{code} {
+      allow get, list: if isAnyAuthenticated()
+        && timestamp.value(resource.data.createdAt.toMillis() + 30 * 60 * 1000) > request.time
+      ;
+      allow create: if isAnyAuthenticated()
+        && request.resource.data.groupId is string
+        && isUserBelongingToGroup(request.resource.data.groupId)
+        // && request.resource.data.expiredAt is timestamp // TODO: 30分以内に作成された招待コードのみ読み取れるので、有効期限は不要な気がする
+        && request.resource.data.createdAt == request.time
+      ;
+    }
   }
 }

--- a/rules.test.ts
+++ b/rules.test.ts
@@ -9,7 +9,7 @@ const databaseName = 'moga-firestore'
 const rules = fs.readFileSync('./firestore.rules', 'utf8')
 
 // firestore client for admin
-const adminDB = firebase.initializeAdminApp({ projectId: projectID, databaseName })
+const adminDB = firebase.initializeAdminApp({ projectId: projectID, databaseName }).firestore()
 
 type Auth = {
   uid?: string,
@@ -20,19 +20,83 @@ type Auth = {
 // firestore client for client-side user
 const clientDB = (auth?: Auth) => firebase.initializeTestApp({ projectId: projectID, databaseName, auth }).firestore()
 
+const serverTimestamp = () => firebase.firestore.FieldValue.serverTimestamp()
+
 // setup and clean up
 
 beforeAll(async () => {
-  await firebase.loadFirestoreRules({ projectId: projectID, rules });
+  await firebase.loadFirestoreRules({ projectId: projectID, rules })
 })
 
 beforeEach(async () => {
-  await firebase.clearFirestoreData({ projectId: projectID });
+  await firebase.clearFirestoreData({ projectId: projectID })
 })
 
 afterAll(async () => {
-  await Promise.all(firebase.apps().map(app => app.delete()));
+  await Promise.all(firebase.apps().map(app => app.delete()))
 })
 
-describe('write test case', () => {
+describe('/users', () => {
+  describe('update', () => {
+    const userId = randomID()
+    const db = clientDB({ uid: userId})
+
+    describe('「groupCount」が更新されている', () => {
+      describe('「updateAt」がリクエストした時間と一致していない', () => {
+        it('更新できない', async () => {
+          await configureTestData('users', userId)
+
+          await firebase.assertFails(db.collection('users').doc(userId).set({
+            groupCount: 1,
+            updatedAt: 'failed'
+          }))
+        })
+      })
+      describe('「updateAt」がリクエストした時間と一致している', () => {
+        it('更新できない', async () => {
+          await configureTestData('users', userId)
+
+          await firebase.assertFails(db.collection('users').doc(userId).set({
+            groupCount: 1,
+            updatedAt: serverTimestamp()
+          }))
+        })
+      })
+    })
+    describe('「groupCount」が更新されていない', () => {
+      describe('「updateAt」がリクエストした時間と一致していない', () => {
+        it('更新できない', async () => {
+          await configureTestData('users', userId)
+
+          await firebase.assertFails(db.collection('users').doc(userId).set({
+            groupCount: 0,
+            updatedAt: 'failed'
+          }))
+        })
+      })
+      describe('「updateAt」がリクエストした時間と一致している', () => {
+        it('更新できる', async () => {
+          await configureTestData('users', userId)
+
+          await firebase.assertSucceeds(db.collection('users').doc(userId).set({
+            groupCount: 0,
+            updatedAt: serverTimestamp()
+          }))
+        })
+      })
+    })
+  })
 })
+
+function configureTestData(collectionId: string, documentId: string) {
+  const db = adminDB
+
+  return db.collection(collectionId).doc(documentId).set(createTestUser())
+}
+
+function createTestUser() {
+  return {
+    groupCount: 0,
+    updatedAt: serverTimestamp()
+  }
+}


### PR DESCRIPTION
動画を参考にセキュリティルールを書きましたが、正直自信がありません、、
（動画だと最終的なデータ構造とルールがわからなかったので、模範解答が知りたいです笑）

テストは時間の都合上、 `/users` の `update` のみ行っています。

完成には程遠いので、あまりにも暇なときに見ていただければと思います、、